### PR TITLE
Remove lsass.exe from Defender-disable process termination list

### DIFF
--- a/.Source/GTweak/Utilities/Tweaks/DefenderManager/WindowsDefender.cs
+++ b/.Source/GTweak/Utilities/Tweaks/DefenderManager/WindowsDefender.cs
@@ -455,7 +455,7 @@ namespace GTweak.Utilities.Tweaks.DefenderManager
         private static void TerminateProcess()
         {
             string[] processes = { "smartscreen", "mpdefendercoreservice", "msmpeng", "securityhealthservice", "securityhealthsystray", "securityhealthui", "wuauserv", "searchui", "sechealthui", "configsecuritypolicy", "runtimebroker", "msedge", "ssoncom", "usocoreworker", "defenderbootstrapper", "sensedlpprocessor", "sensetracer",
-            "dlpuseragent", "lsass", "mpam-d", "mpam-fe", "mpam-fe_bd", "mpas-d", "mpas-fe", "mpas-fe_bd", "mpav-d", "mpav-fe", "mpav-fe_bd", "mpcmdrun", "mpcopyaccelerator", "mpdlpcmd", "mpdlpservice", "mpextms", "mpsigstub", "mrt", "msmpengcp", "mssense", "nissrv", "offlinescannershell", "securekernel", "usocoreworker", "securityhealthhost",
+            "dlpuseragent", "mpam-d", "mpam-fe", "mpam-fe_bd", "mpas-d", "mpas-fe", "mpas-fe_bd", "mpav-d", "mpav-fe", "mpav-fe_bd", "mpcmdrun", "mpcopyaccelerator", "mpdlpcmd", "mpdlpservice", "mpextms", "mpsigstub", "mrt", "msmpengcp", "mssense", "nissrv", "offlinescannershell", "securekernel", "usocoreworker", "securityhealthhost",
             "senseap", "senseaptoast", "sensecm", "sensegpparser", "senseidentity", "senseimdscollector", "senseir", "sensendr", "sensesampleuploader", "sensetvm", "sgrmbroker", "healthattestationclientagent", "wdnissvc", "wdboot", "msseccore", "mssecflt", "mssecwfp", "mdcoresvc", "sensece", "senseui", "sensepp", "wdshield", "mipdlp"  };
             CommandExecutor.RunCommandAsTrustedInstaller($@"""{PathLocator.Executable.NSudo}"" -U:T -P:E -CreatePath:S -ShowWindowMode:Hide -Wait cmd /c taskkill /f " + string.Join(" ", processes.Select(p => $"/im {p}.exe")));
         }


### PR DESCRIPTION
## Problem

`WindowsDefender.TerminateProcess()` includes `"lsass"` in the list of processes it force-kills (`taskkill /f /im lsass.exe`) as part of disabling Windows Defender. `lsass.exe` (Local Security Authority Subsystem) is a protected system process - Windows treats its termination as a security violation and forces an immediate system restart, not a normal process exit. This isn't a side effect of the Defender tweak, it's the OS's own self-protection kicking in.

This matches what #129 and #79 both report: an unexpected forced restart / registry left in an inconsistent state right after toggling the Defender tweak, and Defender left in a broken, hard-to-recover state afterward.

## Fix

Remove `"lsass"` from the termination list. Nothing else in the codebase references it (`grep -ri lsass` across `.Source` returns only this one line), so removing it doesn't affect anything else the Defender-disable flow does.

## Verification

I can't safely reproduce this live - killing `lsass.exe` would force-reboot the machine running the test, which isn't something to do just to prove a one-line removal. The evidence here is:
- The line itself (`grep -ri lsass` -> only this one hit).
- LSASS process protection forcing a system restart on termination is documented Windows behavior, not app-specific.
- Two independent bug reports (#129, #79) matching this exact symptom (forced restart / broken Defender state right after this code path runs).
- `msbuild GTweak.sln /t:Rebuild /p:Configuration=Release` succeeds before and after this change (0 errors) - the removal is a pure list-entry deletion with no other code depending on it.

Fixes #129
